### PR TITLE
Remove awscli gem, add awscli from deb instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ruby:2.2
 
+RUN apt-get update
+RUN apt-get install -y \
+    awscli
+
 COPY Gemfile /Gemfile
 RUN bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 # Note: We use a forked copy of fake_sns because the original author does not
 # seem too interested fixing bugs.  Specifically, we are interested in binding
 # our webserver the any address.  See https://github.com/yourkarma/fake_sns/pull/5
-gem 'awscli'
 gem 'thin'
 gem 'fake_sns', git: 'https://github.com/feathj/fake_sns.git'


### PR DESCRIPTION
- Remove awscli gem (thought it's Amazon's official - false)
- Add awscli through package manager
